### PR TITLE
Optimize stylus stroke rendering latency and smoothness

### DIFF
--- a/InkCanvasForClass-Remastered/Helpers/MultiTouchInput.cs
+++ b/InkCanvasForClass-Remastered/Helpers/MultiTouchInput.cs
@@ -62,11 +62,28 @@ namespace InkCanvasForClass_Remastered.Helpers
             {
                 StylusPointCollection collection = new() { point };
                 Stroke = new Stroke(collection) { DrawingAttributes = _drawingAttributes };
+                return;
             }
-            else
+
+            Stroke.StylusPoints.Add(point);
+        }
+
+        /// <summary>
+        ///     在笔迹中批量添加点
+        /// </summary>
+        /// <param name="points"></param>
+        public void AddRange(StylusPointCollection points)
+        {
+            if (points.Count == 0)
+                return;
+
+            if (Stroke == null)
             {
-                Stroke.StylusPoints.Add(point);
+                Stroke = new Stroke(points.Clone()) { DrawingAttributes = _drawingAttributes };
+                return;
             }
+
+            Stroke.StylusPoints.Add(points);
         }
 
         /// <summary>

--- a/InkCanvasForClass-Remastered/MainWindow.xaml.cs
+++ b/InkCanvasForClass-Remastered/MainWindow.xaml.cs
@@ -4692,19 +4692,32 @@ namespace InkCanvasForClass_Remastered
                 return;
 
             TouchDownPointsList[e.StylusDevice.Id] = InkCanvasEditingMode.None;
+
+            // 在落笔瞬间就注入首批点，降低“触笔到出墨”的首帧延迟
+            var strokeVisual = GetStrokeVisual(e.StylusDevice.Id);
+            strokeVisual.AddRange(e.GetStylusPoints(inkCanvas));
+            strokeVisual.Redraw();
         }
 
-        private async void MainWindow_StylusUp(object sender, StylusEventArgs e)
+        private void MainWindow_StylusUp(object sender, StylusEventArgs e)
         {
             //Logger.LogDebug("StylusUp event triggered");
             try
             {
-                inkCanvas.Strokes.Add(GetStrokeVisual(e.StylusDevice.Id).Stroke);
-                await Task.Delay(5); // 避免渲染墨迹完成前预览墨迹被删除导致墨迹闪烁
-                inkCanvas.Children.Remove(GetVisualCanvas(e.StylusDevice.Id));
+                var strokeVisual = GetStrokeVisual(e.StylusDevice.Id);
+                if (strokeVisual.Stroke != null)
+                {
+                    inkCanvas.Strokes.Add(strokeVisual.Stroke);
+                    inkCanvas_StrokeCollected(inkCanvas,
+                        new InkCanvasStrokeCollectedEventArgs(strokeVisual.Stroke));
+                }
 
-                inkCanvas_StrokeCollected(inkCanvas,
-                    new InkCanvasStrokeCollectedEventArgs(GetStrokeVisual(e.StylusDevice.Id).Stroke));
+                // 使用 Dispatcher 的低优先级异步移除预览层，避免主路径等待
+                _ = Dispatcher.InvokeAsync(() =>
+                {
+                    var visualCanvas = GetVisualCanvas(e.StylusDevice.Id);
+                    if (visualCanvas != null) inkCanvas.Children.Remove(visualCanvas);
+                }, System.Windows.Threading.DispatcherPriority.Background);
             }
             catch (Exception ex)
             {
@@ -4751,9 +4764,7 @@ namespace InkCanvasForClass_Remastered
                 //}
 
                 var strokeVisual = GetStrokeVisual(e.StylusDevice.Id);
-                var stylusPointCollection = e.GetStylusPoints(this);
-                foreach (var stylusPoint in stylusPointCollection)
-                    strokeVisual.Add(new StylusPoint(stylusPoint.X, stylusPoint.Y, stylusPoint.PressureFactor));
+                strokeVisual.AddRange(e.GetStylusPoints(inkCanvas));
                 strokeVisual.Redraw();
             }
             catch (Exception ex)
@@ -4767,7 +4778,6 @@ namespace InkCanvasForClass_Remastered
             if (StrokeVisualList.TryGetValue(id, out var visual)) return visual;
 
             var strokeVisual = new StrokeVisual(_viewModel.InkCanvasDrawingAttributes.Clone());
-            StrokeVisualList[id] = strokeVisual;
             StrokeVisualList[id] = strokeVisual;
             var visualCanvas = new VisualCanvas(strokeVisual);
             VisualCanvasList[id] = visualCanvas;


### PR DESCRIPTION
### Motivation
- Reduce perceptible delay from touch/stylus down to first visible ink and avoid UI jank during stroke commit. 
- Lower per-point overhead during continuous inking to make strokes smoother under fast movement. 

### Description
- Prime stroke preview on down by creating/getting `StrokeVisual` in `MainWindow_StylusDown`, inject the initial sample batch and call `Redraw()` to show the first frame immediately. 
- Add `AddRange(StylusPointCollection)` to `StrokeVisual` (in `Helpers/MultiTouchInput.cs`) and switch `StylusMove` to call `strokeVisual.AddRange(e.GetStylusPoints(inkCanvas))` to append points in bulk. 
- Remove blocking `Task.Delay(5)` and the `async` StylusUp path, instead commit the `Stroke` synchronously when present and schedule preview-layer removal with `Dispatcher.InvokeAsync(..., DispatcherPriority.Background)`. 
- Minor cleanup: avoid duplicate dictionary assignment in `GetStrokeVisual` and null-check before committing `Stroke` to `inkCanvas.Strokes`. 

### Testing
- Attempted an automated build with `dotnet build InkCanvasForClass-Remastered/InkCanvasForClass-Remastered.csproj`, but the environment lacks the .NET SDK and failed with `dotnet: command not found` so no successful build artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aa10693ac832486e0d469197d51e5)